### PR TITLE
iOS9 fix canOpenURL method

### DIFF
--- a/ios/PPHere/PPHere-Info.plist
+++ b/ios/PPHere/PPHere-Info.plist
@@ -30,6 +30,10 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>paypalhere</string>
+	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ios/PPHere/PPViewController.m
+++ b/ios/PPHere/PPViewController.m
@@ -74,7 +74,8 @@
     NSLog(@"%@", pphUrlString);
     
     UIApplication *application = [UIApplication sharedApplication];
-    if ([application canOpenURL:pphUrl]){
+    //iOS 9 -> Don't forget to add this schema to info.plist as a white schema (http://useyourloaf.com/blog/querying-url-schemes-with-canopenurl.html)
+    if ([application canOpenURL:[NSURL URLWithString:@"paypalhere://"]]){
         [application openURL:pphUrl];
     } else {
         NSURL *url = [NSURL URLWithString:@"itms://itunes.apple.com/us/app/paypal-here/id505911015?mt=8"];


### PR DESCRIPTION
Apple continues to put a high priority on protecting the privacy of a user so it should be no surprise that iOS 9 brings new security and privacy measures. One such measure is to prevent the abuse of canOpenURL to discover the Apps a user has installed.

http://useyourloaf.com/blog/querying-url-schemes-with-canopenurl.html